### PR TITLE
Set optional attributes more explicitly.

### DIFF
--- a/lib/bound.rb
+++ b/lib/bound.rb
@@ -18,23 +18,17 @@ class Bound
       attr_accessor :attributes, :optionals
 
       def set_attributes(*attributes)
-        attributes = attributes.dup
-
-        optionals = extract_optionals(attributes)
-
-        self.optionals = optionals
-        attr_accessor(*optionals)
-
         self.attributes = attributes
-        attr_accessor(*attributes)
+        attr_accessor *attributes
+
+        self.optionals = []
       end
 
-      def extract_optionals(attributes)
-        if attributes.last.kind_of? Hash
-          attributes.pop[:optional]
-        else
-          []
-        end
+      def optional(*optionals)
+        self.optionals = optionals
+        attr_accessor *optionals
+
+        self
       end
     end
 

--- a/spec/bound_spec.rb
+++ b/spec/bound_spec.rb
@@ -47,7 +47,7 @@ describe Bound do
   end
 
   describe 'optional attributes' do
-    UserWithoutAge = Bound.new(:name, :optional => [:age])
+    UserWithoutAge = Bound.new(:name).optional(:age)
 
     it 'sets optional attributes' do
       [hash, object].each do |subject|


### PR DESCRIPTION
After this commit you can do

```
Bound.new(:name).optional(:age, :sex)
```

instead of

```
Bound.new(:name, :optional => [:age, :sex])
```

WDYT?
