### PR TITLE
Missing optional attributes

### DIFF
--- a/lib/bound.rb
+++ b/lib/bound.rb
@@ -240,7 +240,7 @@ class Bound
       code = <<-EOR
         def #{prefix}#{attr}
           return @o[:#{attr}] if @o && @o.key?(:#{attr})
-          return @t.kind_of?(Hash) ? @t[:#{attr}] : @t.#{attr} if @t
+          return @t.kind_of?(Hash) ? @t[:#{attr}] : @t.respond_to?(:#{attr}) ? @t.#{attr} : nil if @t
           nil
         end
       EOR

--- a/lib/bound.rb
+++ b/lib/bound.rb
@@ -239,9 +239,15 @@ class Bound
     def self.define_delegate(attr, prefix = '')
       code = <<-EOR
         def #{prefix}#{attr}
-          return @o[:#{attr}] if @o && @o.key?(:#{attr})
-          return @t.kind_of?(Hash) ? @t[:#{attr}] : @t.respond_to?(:#{attr}) ? @t.#{attr} : nil if @t
-          nil
+          if @o && @o.key?(:#{attr})
+            @o[:#{attr}]
+          elsif @t
+            if @t.kind_of?(Hash)
+              @t[:#{attr}]
+            elsif @t.respond_to?(:#{attr})
+              @t.#{attr}
+            end
+          end
         end
       EOR
       class_eval code

--- a/spec/bound_spec.rb
+++ b/spec/bound_spec.rb
@@ -366,5 +366,21 @@ describe Bound do
     end
   end
 
+  describe 'bug: raises error if optional attribute does not exist in input' do
+    Person = Bound.optional(:gender)
+
+    let(:the_hash) { {} }
+    let(:object)   { HashObject.new({}) }
+
+    it 'for object' do
+      person = Person.new(object)
+      assert_nil person.gender
+    end
+
+    it 'for hash' do
+      person = Person.new(the_hash)
+      assert_nil person.gender
+    end
+  end
 
 end


### PR DESCRIPTION
Bound should not enforce method call for optional attributes for object input.

\cc @JanOwiesniak @shlub @splattael 