### PR TITLE
Use semantic validation error classes

### DIFF
--- a/lib/bound.rb
+++ b/lib/bound.rb
@@ -1,5 +1,6 @@
 require "bound/version"
 require "bound/caller"
+require "bound/errors"
 
 class Bound
   def self.new(*args)
@@ -58,7 +59,7 @@ class Bound
       a.each do |attr|
         unless b.include? attr
           message = "Unknown attribute: #{attr.inspect} in #{b}"
-          raise ArgumentError, message
+          raise UnknownAttributeError, message
         end
       end
     end
@@ -66,7 +67,7 @@ class Bound
     def ensure_present!(attribute)
       if !overwritten?(attribute) && !target_has?(attribute)
         message = "Missing attribute: #{attribute}"
-        raise ArgumentError, message
+        raise MissingAttributeError, message
       end
     end
 

--- a/lib/bound/errors.rb
+++ b/lib/bound/errors.rb
@@ -1,0 +1,5 @@
+class MissingAttributeError < ArgumentError
+end
+
+class UnknownAttributeError < ArgumentError
+end

--- a/spec/bound_spec.rb
+++ b/spec/bound_spec.rb
@@ -29,7 +29,7 @@ describe Bound do
     the_hash.delete :age
 
     [the_hash, object].each do |subject|
-      exception = assert_raises ArgumentError, subject.inspect do
+      exception = assert_raises MissingAttributeError, subject.inspect do
         User.new(subject)
       end
 
@@ -49,7 +49,7 @@ describe Bound do
     the_hash[:gender] = "M"
     subject = the_hash
 
-    exception = assert_raises ArgumentError, subject.inspect do
+    exception = assert_raises UnknownAttributeError, subject.inspect do
       User.new(subject)
     end
 
@@ -172,7 +172,7 @@ describe Bound do
     it 'fails if argument of optional nested bound is missing' do
       the_hash[:profile].delete(:age)
       [the_hash, object].each do |subject|
-        error = assert_raises ArgumentError do
+        error = assert_raises MissingAttributeError do
           UserWithProfile.new(subject)
         end
         assert_match(/missing/i, error.message)
@@ -213,7 +213,7 @@ describe Bound do
     it 'fails if nested attributes are missing' do
       the_hash[:company].delete(:name)
       [the_hash, object].each do |subject|
-        error = assert_raises ArgumentError do
+        error = assert_raises MissingAttributeError do
           EmployedUser.new(subject)
         end
         assert_match(/missing/i, error.message)
@@ -257,7 +257,7 @@ describe Bound do
     it 'fails if nested bound is missing an attribute' do
       the_hash[:posts][1].delete(:title)
       [the_hash, object].each do |subject|
-        error = assert_raises ArgumentError do
+        error = assert_raises MissingAttributeError do
           BloggingUser.new(subject)
         end
         assert_match(/missing/i, error.message)


### PR DESCRIPTION
Instead of throwing a generic `ArgumentError` during Bound validations, use semantic errors, namely `MissingAttributeError` and `UnknownAttributeError`

:kissing_heart: 